### PR TITLE
Forcibly use Python 2

### DIFF
--- a/autoload/clighter8.vim
+++ b/autoload/clighter8.vim
@@ -8,7 +8,7 @@ fun! clighter8#start()
 
     let s:channel = ch_open('localhost:8787')
     if ch_status(s:channel) ==# 'fail'
-        let l:cmd = 'python '. s:script_folder_path.'/../python/engine.py '. g:clighter8_logfile
+        let l:cmd = 'python2 '. s:script_folder_path.'/../python/engine.py '. g:clighter8_logfile
         let s:job = job_start(l:cmd, {'stoponexit': '', 'in_io': 'null', 'out_io': 'null', 'err_io': 'null'})
         let s:channel = ch_open('localhost:8787', {'waittime': 500})
         if ch_status(s:channel) ==# 'fail'

--- a/python/engine.py
+++ b/python/engine.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/python2
 
 import logging
 import json


### PR DESCRIPTION
On some systems (e.g. on Arch Linux), `python` refers to Python 3, while on most systems, it is Python 2. Since clighter8 is written in Python 2, invoking it with `python` won't work if Python 3 is the default. Invoke `python2` instead of `python` so that it works on all systems.